### PR TITLE
Add array pop

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -10,6 +10,7 @@ extern "C" {
     pub fn rb_ary_new() -> Value;
     pub fn rb_ary_push(array: Value, item: Value) -> Value;
     pub fn rb_ary_store(array: Value, index: c_long, item: Value) -> Value;
+    pub fn rb_ary_pop(array: Value) -> Value;
 }
 
 #[repr(C)]


### PR DESCRIPTION
@steveklabnik @d-unseductable  is this sufficient to make `array::rb_ary_pop` works ?
