### PR TITLE
Add missing externs for Array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-sys"
-version = "0.2.13"
+version = "0.3.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>",
            "Dmitry Gritsay <unseductable@gmail.com>"]
 description = "Low level bindings to MRI, Matz's Ruby Interpreter."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-sys"
-version = "0.3.0"
+version = "0.2.13"
 authors = ["Steve Klabnik <steve@steveklabnik.com>",
            "Dmitry Gritsay <unseductable@gmail.com>"]
 description = "Low level bindings to MRI, Matz's Ruby Interpreter."

--- a/src/array.rs
+++ b/src/array.rs
@@ -5,17 +5,20 @@ use constant::{FL_USHIFT, FL_USER_1, FL_USER_3, FL_USER_4};
 use types::{c_long, InternalValue, RBasic, Value};
 
 extern "C" {
+    pub fn rb_ary_concat(array: Value,other_array: Value) -> Value;
+    pub fn rb_ary_dup(array: Value) -> Value;
     pub fn rb_ary_entry(array: Value, offset: c_long) -> Value;
     pub fn rb_ary_join(array: Value, separator: Value) -> Value;
     pub fn rb_ary_new() -> Value;
-    pub fn rb_ary_push(array: Value, item: Value) -> Value;
-    pub fn rb_ary_store(array: Value, index: c_long, item: Value) -> Value;
     pub fn rb_ary_pop(array: Value) -> Value;
-    pub fn rb_ary_unshift(array: Value, item: Value) -> Value;
-    pub fn rb_ary_shift(array: Value) -> Value;
-    pub fn rb_ary_dup(array: Value) -> Value;
-    pub fn rb_ary_to_s(array: Value) -> Value;
+    pub fn rb_ary_push(array: Value, item: Value) -> Value;
     pub fn rb_ary_reverse(array: Value) -> Value;
+    pub fn rb_ary_shift(array: Value) -> Value;
+    pub fn rb_ary_sort_bang(array: Value) -> Value;
+    pub fn rb_ary_sort(array: Value) -> Value;
+    pub fn rb_ary_store(array: Value, index: c_long, item: Value) -> Value;
+    pub fn rb_ary_to_s(array: Value) -> Value;
+    pub fn rb_ary_unshift(array: Value, item: Value) -> Value;
 }
 
 #[repr(C)]

--- a/src/array.rs
+++ b/src/array.rs
@@ -11,6 +11,11 @@ extern "C" {
     pub fn rb_ary_push(array: Value, item: Value) -> Value;
     pub fn rb_ary_store(array: Value, index: c_long, item: Value) -> Value;
     pub fn rb_ary_pop(array: Value) -> Value;
+    pub fn rb_ary_unshift(array: Value, item: Value) -> Value;
+    pub fn rb_ary_shift(array: Value) -> Value;
+    pub fn rb_ary_dup(array: Value) -> Value;
+    pub fn rb_ary_to_s(array: Value) -> Value;
+    pub fn rb_ary_reverse(array: Value) -> Value;
 }
 
 #[repr(C)]

--- a/src/array.rs
+++ b/src/array.rs
@@ -5,7 +5,7 @@ use constant::{FL_USHIFT, FL_USER_1, FL_USER_3, FL_USER_4};
 use types::{c_long, InternalValue, RBasic, Value};
 
 extern "C" {
-    pub fn rb_ary_concat(array: Value,other_array: Value) -> Value;
+    pub fn rb_ary_concat(array: Value, other_array: Value) -> Value;
     pub fn rb_ary_dup(array: Value) -> Value;
     pub fn rb_ary_entry(array: Value, offset: c_long) -> Value;
     pub fn rb_ary_join(array: Value, separator: Value) -> Value;


### PR DESCRIPTION
- Bump version to 0.3.0
- Add unshift, shift, dup, to_s and reverse to Array
