### PR TITLE
Add option to build against the Ruby static library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::process::Command;
 
 fn rbconfig(key: &str) -> Vec<u8> {
@@ -12,8 +13,12 @@ fn rbconfig(key: &str) -> Vec<u8> {
 
 fn main() {
     let libdir = rbconfig("libdir");
-    let soname = rbconfig("RUBY_SO_NAME");
-
     println!("cargo:rustc-link-search={}", String::from_utf8_lossy(&libdir));
-    println!("cargo:rustc-link-lib=dylib={}", String::from_utf8_lossy(&soname));
+
+    if env::var_os("USE_LIBRUBY_A").is_some() {
+        println!("cargo:rustc-link-lib=static=ruby-static");
+    } else {
+        let soname = rbconfig("RUBY_SO_NAME");
+        println!("cargo:rustc-link-lib=dylib={}", String::from_utf8_lossy(&soname));
+    }
 }


### PR DESCRIPTION
If the environment variable `USE_LIBRUBY_A` is set, link `ruby-sys` against the given Ruby's static library instead of the shared library. This is necessary for environments such as Heroku's Ruby buildpack, which is not built with `--enable-shared`.

CC: @steveklabnik since there was interest on Twitter.