### PR TITLE
Add support for RUBY environment variable when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Low-level bindings to Ruby, for Rust.
 
 [![Build Status](https://travis-ci.org/steveklabnik/ruby-sys.svg?branch=master)](https://travis-ci.org/steveklabnik/ruby-sys)
+
+## Building with non-default Rubies
+
+By default, the bindings use the `ruby` in the system path to determine the build parameters. If a
+non-system Ruby needs to be used, use the `RUBY` environment variable to specify the absolute path
+to the Ruby executable.

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,19 @@
+use std::env;
+use std::ffi::OsStr;
 use std::process::Command;
 
 fn rbconfig(key: &str) -> Vec<u8> {
-    let ruby = Command::new("ruby")
-                   .arg("-e")
-                   .arg(format!("print RbConfig::CONFIG['{}']", key))
-                   .output()
-                   .unwrap_or_else(|e| panic!("ruby not found: {}", e));
+    let ruby = match env::var_os("RUBY") {
+        Some(val) => val.to_os_string(),
+        None => OsStr::new("ruby").to_os_string(),
+    };
+    let config = Command::new(ruby)
+        .arg("-e")
+        .arg(format!("print RbConfig::CONFIG['{}']", key))
+        .output()
+        .unwrap_or_else(|e| panic!("ruby not found: {}", e));
 
-    ruby.stdout
+    config.stdout
 }
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,8 @@ fn main() {
     let libdir = rbconfig("libdir");
     let soname = rbconfig("RUBY_SO_NAME");
 
-    println!("cargo:rustc-link-search={}", String::from_utf8_lossy(&libdir));
-    println!("cargo:rustc-link-lib=dylib={}", String::from_utf8_lossy(&soname));
+    println!("cargo:rustc-link-search={}",
+             String::from_utf8_lossy(&libdir));
+    println!("cargo:rustc-link-lib=dylib={}",
+             String::from_utf8_lossy(&soname));
 }


### PR DESCRIPTION
Defaults to the system Ruby when the environment variable is not found.

Also ran `rustfmt` on `build.rs`.

Fixes #18.