### PR TITLE
Support static linking for Ruby

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,12 +16,47 @@ fn rbconfig(key: &str) -> Vec<u8> {
     config.stdout
 }
 
+fn use_static() {
+    let ruby_libs = rbconfig("LIBS");
+    let libs = String::from_utf8_lossy(&ruby_libs);
+
+    // Ruby gives back the libs in the form: `-lpthread -lgmp`
+    // Cargo wants them as: `-l pthread -l gmp`
+    let transformed_lib_args = libs.replace("-l", "-l ");
+
+    println!("cargo:rustc-link-lib=static=ruby-static");
+    println!("cargo:rustc-flags={}", transformed_lib_args);
+}
+
+fn use_dylib(lib: Vec<u8>) {
+    println!("cargo:rustc-link-lib=dylib={}",
+             String::from_utf8_lossy(&lib));
+}
+
 fn main() {
     let libdir = rbconfig("libdir");
-    let soname = rbconfig("RUBY_SO_NAME");
+
+    let libruby_static = rbconfig("LIBRUBY_A");
+    let libruby_so = rbconfig("RUBY_SO_NAME");
+
+    match (libruby_static.is_empty(), libruby_so.is_empty()) {
+        (false, true) => use_static(),
+        (true, false) => use_dylib(libruby_so),
+        (false, false) => {
+            if env::var_os("RUBY_STATIC").is_some() {
+                use_static()
+            } else {
+                use_dylib(libruby_so)
+            }
+        },
+        _ => {
+            let msg = "Error! Could not find LIBRUBY_A or RUBY_SO_NAME. \
+            This means that no static, or dynamic libruby was found. \
+            Possible solution: build a new Ruby with the `--enable-shared` configure opt.";
+            panic!(msg)
+        }
+    }
 
     println!("cargo:rustc-link-search={}",
              String::from_utf8_lossy(&libdir));
-    println!("cargo:rustc-link-lib=dylib={}",
-             String::from_utf8_lossy(&soname));
 }


### PR DESCRIPTION
This approach essentially follows the logic outlined by @alexcrichton in [this issue](https://github.com/steveklabnik/ruby-sys/pull/16#issuecomment-271412827).

I have tested it on Linux against `ruru` and a few other gems, and things seem to be working. The only hiccup I found was that we needed to specify the `LIBS` which were used from Ruby. With the approach on #16, this was not neccesary. I am not sure why. Does anyone have any insight to this?

Any feedback would be awesome, especially if you are a Mac user.

### Easy way to test things out

1. Clone ruru: `https://github.com/d-unseductable/ruru`
1. Update Cargo.toml in ruru: `ruby-sys = { git = "https://github.com/ianks/ruby-sys" }`
1. Run the tests: `RUBY_STATIC=1 cargo test`