### PR TITLE
Introduce rb_proc_new and test it

### DIFF
--- a/src/rproc.rs
+++ b/src/rproc.rs
@@ -6,4 +6,6 @@ extern "C" {
                                    argv: *const Value,
                                    pass_procval: Value)
                                    -> Value;
+
+    pub fn rb_proc_new(func: extern fn(Value) -> Value, binding: Value) -> Value;
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2,6 +2,7 @@ use types::{CallbackPtr, c_char, c_int, c_void, Value};
 
 extern "C" {
     pub fn ruby_init();
+    pub fn ruby_cleanup(code: c_int) -> c_int;
     pub fn rb_block_proc() -> Value;
     pub fn rb_block_given_p() -> c_int;
     pub fn rb_raise(exception: Value, message: *const c_char);

--- a/tests/rproc_test.rs
+++ b/tests/rproc_test.rs
@@ -1,0 +1,25 @@
+extern crate ruby_sys;
+use ruby_sys::{vm,rproc, value, fixnum};
+
+#[test]
+fn rb_proc_new_works_with_one_argument() {
+    unsafe { vm::ruby_init() };
+
+    let nil = value::Value { value: value::RubySpecialConsts::Nil as usize };
+
+    extern fn test_fn(v: value::Value) -> value::Value {
+        return v;
+    }
+
+    unsafe {
+        let val = fixnum::rb_int2inum(3);
+        let rproc = rproc::rb_proc_new(test_fn, nil);
+        let result = rproc::rb_proc_call_with_block(rproc, 1, vec![val].as_ptr(), nil);
+
+        assert!(!result.is_nil());
+        let val_result = fixnum::rb_num2int(result);
+        assert!(3 == val_result);
+    }
+
+    unsafe { vm::ruby_cleanup(0) };
+}


### PR DESCRIPTION
I tried making it accept more than one arguments, but failed. If I make it be variadic, and then transmute multi-argument function references to that, the second argument will still always be nil. I don't know enough about variadic argument functions to understand why this would happen.

I'm not sure if this is good to merge in as it is, since a proper variadic implementation might not be compatible with consumers of this API.

Also, I hope you don't mind I made a test for it, it helped find the right signatures and finding out if all the values were being set correctly. Also I think it's nice if there's examples of how to use these functions in here, because there sure aren't any in the Ruby codebase.