### PR TITLE
Add rb_block_call and rb_id2name to util.rs

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3,5 +3,7 @@ use types::{Argc, c_char, Id, Value};
 extern "C" {
     pub fn rb_const_get(klass: Value, id: Id) -> Value;
     pub fn rb_funcallv(receiver: Value, method: Id, argc: Argc, argv: *const Value) -> Value;
+    pub fn rb_block_call(obj: Value, method_id: Id, argc: Argc, argv: *const Value, block: extern fn(Value, Value, Argc, *const Value) -> Value, outer_scope: Value) -> Value;
     pub fn rb_intern(name: *const c_char) -> Id;
+    pub fn rb_id2name(method_id: Id) -> *const c_char;
 }


### PR DESCRIPTION
`rb_block_call` is necessary to call methods with blocks. `rb_id2name` is a nice convenience method for reversing a method ID to its name.

We ran across a use-case that requires us to be able to pass a Rust function as a block to Ruby. Adding the `rb_block_call` binding enables us to do that.