### PR TITLE
Add string::rb_utf8_str_new function

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -7,6 +7,7 @@ use types::{c_char, c_long, InternalValue, RBasic, Value};
 extern "C" {
     pub fn rb_str_new(str: *const c_char, len: c_long) -> Value;
     pub fn rb_str_new_cstr(str: *const c_char) -> Value;
+    pub fn rb_utf8_str_new(str: *const c_char, len: c_long) -> Value;
     pub fn rb_string_value_cstr(str: *const Value) -> *const c_char;
     pub fn rb_string_value_ptr(str: *const Value) -> *const c_char;
 }


### PR DESCRIPTION
This function will return a new Ruby string with UTF8 encoding. This commit is for the issue described in d-unseductable/ruru#67.