### PR TITLE
Static builds on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 # Based on https://github.com/malept/rusty_blank/blob/master/.travis.yml
 # and https://github.com/d-unseductable/ruru/blob/master/.travis.yml
 
-language: rust
+os:
+- linux
+- osx
+sudo: false
+dist: trusty
+osx_image: xcode8.2
 
+language: rust
 rust:
   - stable
   - beta
@@ -15,7 +21,10 @@ addons:
     - libelf-dev
     - libdw-dev
 
-cache: cargo
+cache:
+  cargo: true
+  directories:
+  - $HOME/.cache/pip
 
 matrix:
   allow_failures:
@@ -31,7 +40,7 @@ before_install:
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  export PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
 
 script:
 - |
@@ -43,5 +52,11 @@ env:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
   matrix:
     - BUILD_RUBY_VERSION: 2.2.5
+    - BUILD_RUBY_VERSION: 2.2.5
+      RUBY_STATIC: 1
     - BUILD_RUBY_VERSION: 2.3.1
-    - BUILD_RUBY_VERSION: 2.4.0
+    - BUILD_RUBY_VERSION: 2.3.1
+      RUBY_STATIC: 1
+    - BUILD_RUBY_VERSION: 2.4.1
+    - BUILD_RUBY_VERSION: 2.4.1
+      RUBY_STATIC: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ rust:
   - beta
   - nightly
 
-addons:
-  apt:
-    packages:
-    - libcurl4-openssl-dev
-    - libelf-dev
-    - libdw-dev
-
 cache:
   cargo: true
   directories:


### PR DESCRIPTION
Don't link to libruby-static.

Use `libdir` to find the appropriate Ruby library.

Use `ENABLE_SHARED` instead of `LIBRUBY_A` to determine whether to link to the dynamic library.

Disable static linking on Windows (for now).

Also, do some cleanup in the Travis config.